### PR TITLE
Allow <!--#include as well as <!-- #include

### DIFF
--- a/lib/connect-include.js
+++ b/lib/connect-include.js
@@ -29,7 +29,7 @@ module.exports = function shtmlEmulator(rootDir) {
             }
 
             var body = buffer.getContentsAsString();
-            var includes = body.match(/<!-- #include file=\".+\" -->/g);
+            var includes = body.match(/<!--\s?#include file=\".+\" -->/g);
             if (!includes) {
                 return oldEnd.call(this, body);
             }
@@ -38,7 +38,7 @@ module.exports = function shtmlEmulator(rootDir) {
             var remaining = includes.length;
 
             _.each(includes, function(include) {
-                var file = path.join(rootDir, include.match(/<!-- #include file=\"(.+)\" -->/)[1]);
+                var file = path.join(rootDir, include.match(/<!--\s?#include file=\"(.+)\" -->/)[1]);
 
                 fs.readFile(file, 'utf8', function(err, data) {
                     if(err) {


### PR DESCRIPTION
Apache (which is the destination server in my simple case) requires a slightly different include syntax.  This pull request makes the space between <!-- and #include optional.  Existing users won't notice the difference, but life much easier for those whose destination server requires <!--#include not <!-- #include
