### PR TITLE
Check relative file instead of absolute, following the standard

### DIFF
--- a/lib/connect-include.js
+++ b/lib/connect-include.js
@@ -20,18 +20,20 @@ module.exports = function shtmlEmulator(rootDir) {
 
         var oldEnd = res.end;
         res.end = function(data) {
+			var context = this;
+		
             if(data) {
                 buffer.write(data);
             }
 
             if (!buffer.size()) {
-                return oldEnd.call(this, buffer.getContents());
+                return oldEnd.call(context, buffer.getContents());
             }
 
             var body = buffer.getContentsAsString();
             var includes = body.match(/<!--\s?#include (virtual|file)=\".+\" -->/g);
             if (!includes) {
-                return oldEnd.call(this, body);
+                return oldEnd.call(context, body);
             }
 
 			var remaining = includes.length;
@@ -55,7 +57,7 @@ module.exports = function shtmlEmulator(rootDir) {
                     }
 					
                     if (!--remaining) {
-                        oldEnd.call(this, body);
+                        oldEnd.call(context, body);
                     }
                 });
             });


### PR DESCRIPTION
The file attribute is a file path, relative to the current directory. That means that it cannot be an absolute file path (starting with /), nor can it contain ../ as part of that path

Please add this to your master branch.

see: http://httpd.apache.org/docs/2.2/howto/ssi.html
